### PR TITLE
✈ [FEAT] 에러 전역관리 AOP 추가

### DIFF
--- a/src/main/java/lotbook/lotbook/enums/ErrorCode.java
+++ b/src/main/java/lotbook/lotbook/enums/ErrorCode.java
@@ -1,0 +1,19 @@
+package lotbook.lotbook.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    ERROR_CODE_1("E001", "에러메세지를 이렇게 작성해주시면 됩니다."),
+
+    ERROR_CODE_2("E002", "에러메세지를 이렇게 작성해주세요.");
+
+
+
+
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/lotbook/lotbook/exception/CustomException.java
+++ b/src/main/java/lotbook/lotbook/exception/CustomException.java
@@ -1,0 +1,16 @@
+package lotbook.lotbook.exception;
+
+import lotbook.lotbook.enums.ErrorCode;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+}

--- a/src/main/java/lotbook/lotbook/exception/GlobalExceptionHandler.java
+++ b/src/main/java/lotbook/lotbook/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package lotbook.lotbook.exception;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.ModelAndView;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ModelAndView handleCustomException(CustomException ex) {
+
+        ModelAndView modelAndView = new ModelAndView("index"); // error는 JSP 파일명
+
+        modelAndView.addObject("center", "error");
+        modelAndView.addObject("errorCode", ex.getErrorCode().getCode());
+        modelAndView.addObject("errorMessage", ex.getErrorCode().getMessage());
+
+        return modelAndView;
+
+    }
+}

--- a/src/main/java/lotbook/lotbook/service/ProductService.java
+++ b/src/main/java/lotbook/lotbook/service/ProductService.java
@@ -3,6 +3,7 @@ package lotbook.lotbook.service;
 import lotbook.lotbook.dto.entity.OrderDetail;
 import lotbook.lotbook.dto.entity.Product;
 import lotbook.lotbook.dto.response.ProductDetailWithReviews;
+import lotbook.lotbook.exception.CustomException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,7 +11,7 @@ public interface ProductService {
 
     Product get(int sequence);
 
-    ProductDetailWithReviews getProductDetail(long sequence);
+    ProductDetailWithReviews getProductDetail(long sequence) throws CustomException;
     
     int updateByProductKeyWithSalesCount(OrderDetail v) throws Exception;
 

--- a/src/main/java/lotbook/lotbook/service/ProductServiceImpl.java
+++ b/src/main/java/lotbook/lotbook/service/ProductServiceImpl.java
@@ -9,9 +9,12 @@ import lotbook.lotbook.dto.mapper.ProductRelatedNameMapperDTO;
 import lotbook.lotbook.dto.mapper.ReviewWithNameMapperDTO;
 import lotbook.lotbook.dto.response.ProductDetailWithReviews;
 import lotbook.lotbook.enums.ProductStateEnum;
+import lotbook.lotbook.exception.CustomException;
 import lotbook.lotbook.repository.ProductMapper;
 import lotbook.lotbook.repository.ReviewMapper;
 import org.springframework.stereotype.Service;
+
+import static lotbook.lotbook.enums.ErrorCode.ERROR_CODE_1;
 
 
 @Service
@@ -27,47 +30,53 @@ public class ProductServiceImpl implements ProductService {
 	}
 
     @Override
-    public ProductDetailWithReviews getProductDetail(long sequence) {
-        Product product = productMapper.selectProductBySequence(sequence);
-        ProductRelatedNameMapperDTO relatedName = productMapper.selectRelatedNameAndCategoryByProductSequence(sequence);
-        List<ReviewWithNameMapperDTO> reviews = reviewMapper.selectReviewsByProductSequence(sequence);
-        double avgRating = 0;
+    public ProductDetailWithReviews getProductDetail(long sequence) throws CustomException {
+            Product product = productMapper.selectProductBySequence(sequence);
+            if (product == null) {
+                throw new CustomException(ERROR_CODE_1);
+            }
 
-        if (!reviews.isEmpty()) {
-            avgRating = reviews.stream().mapToInt(ReviewWithNameMapperDTO::getRating).average().orElse(0.0);
+            ProductRelatedNameMapperDTO relatedName = productMapper.selectRelatedNameAndCategoryByProductSequence(sequence);
+            List<ReviewWithNameMapperDTO> reviews = reviewMapper.selectReviewsByProductSequence(sequence);
+            double avgRating = 0;
+
+            if (!reviews.isEmpty()) {
+                avgRating = reviews.stream().mapToInt(ReviewWithNameMapperDTO::getRating).average().orElse(0.0);
+            }
+            int discountedPrice = (product.getPrice() * (int) (100.0 - product.getDiscountRate()) / 100) / 10 * 10;
+            int pointAccumulation = (int) (product.getPrice() * product.getPointAccumulationRate() / 100);
+
+            return ProductDetailWithReviews.builder()
+                    .sequence(product.getSequence())
+                    .productImgurl(product.getProductImgurl())
+                    .productDetailImgurl(product.getProductDetailImgurl())
+                    .name(product.getName())
+                    .originalPrice(product.getPrice())
+                    .discountRate(product.getDiscountRate())
+                    .price(discountedPrice)
+                    .content(product.getContent())
+                    .stock(product.getStock())
+                    .createdAt(product.getCreatedAt())
+                    .pointAccumulationRate(product.getPointAccumulationRate())
+                    .pointAccumulation(pointAccumulation)
+                    .salesCount(product.getSalesCount())
+                    // TODO: ENUM type handler-from mybatis
+                    .state(ProductStateEnum.ACTIVE)
+                    .authorSequence(product.getAuthorSequence())
+                    .authorName(relatedName.getAuthorName())
+                    .publisherSequence(product.getPublisherSequence())
+                    .publisherName(relatedName.getPublisherName())
+                    .mainCategorySequence(relatedName.getMainCategorySequence())
+                    .mainCategoryName(relatedName.getMainCategoryName())
+                    .subCategorySequence(relatedName.getSubCategorySequence())
+                    .subCategoryName(relatedName.getSubCategoryName())
+                    // TODO: reviewer name handling using dto with optional
+                    .reviews(reviews)
+                    .averageRating(avgRating)
+                    .build();
+
+
         }
-        int discountedPrice = (product.getPrice() * (int) (100.0 - product.getDiscountRate()) / 100) / 10 * 10;
-        int pointAccumulation = (int) (product.getPrice() * product.getPointAccumulationRate() / 100);
-
-        return ProductDetailWithReviews.builder()
-                .sequence(product.getSequence())
-                .productImgurl(product.getProductImgurl())
-                .productDetailImgurl(product.getProductDetailImgurl())
-                .name(product.getName())
-                .originalPrice(product.getPrice())
-                .discountRate(product.getDiscountRate())
-                .price(discountedPrice)
-                .content(product.getContent())
-                .stock(product.getStock())
-                .createdAt(product.getCreatedAt())
-                .pointAccumulationRate(product.getPointAccumulationRate())
-                .pointAccumulation(pointAccumulation)
-                .salesCount(product.getSalesCount())
-                // TODO: ENUM type handler-from mybatis
-                .state(ProductStateEnum.ACTIVE)
-                .authorSequence(product.getAuthorSequence())
-                .authorName(relatedName.getAuthorName())
-                .publisherSequence(product.getPublisherSequence())
-                .publisherName(relatedName.getPublisherName())
-                .mainCategorySequence(relatedName.getMainCategorySequence())
-                .mainCategoryName(relatedName.getMainCategoryName())
-                .subCategorySequence(relatedName.getSubCategorySequence())
-                .subCategoryName(relatedName.getSubCategoryName())
-                // TODO: reviewer name handling using dto with optional
-                .reviews(reviews)
-                .averageRating(avgRating)
-                .build();
-    }
     
     public int updateByProductKeyWithSalesCount(OrderDetail v) throws Exception {
         int result = 0;

--- a/src/main/webapp/WEB-INF/views/error.jsp
+++ b/src/main/webapp/WEB-INF/views/error.jsp
@@ -1,0 +1,123 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+         pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<!-- Header Section Begin -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<header class="header">
+    <div class="header__top">
+        <div class="container">
+            <nav class="header__menu header__top__right mobile-menu"
+                 style="padding: 5px 0">
+                <ul>
+                    <c:choose>
+                        <c:when test="${logincust != null }">
+                            <li class="active"><a href="main.bit?view=mypage&memberSeq=${logincust.sequence }"><i
+                                    class="fa fa-user"></i> 마이페이지</a></li>
+                            <li class=""><a href="member.bit?view=logout"><i
+                                    class="fa fa-user"></i> 로그아웃</a></li>
+                        </c:when>
+                        <c:otherwise>
+                            <li class="active"><a href="/page/signin"><i
+                                    class="fa fa-user"></i> 로그인</a></li>
+                            <li class=""><a href="${pageContext.request.contextPath}/page/signup"><i
+                                    class="fa fa-user"></i> 회원가입</a></li>
+                        </c:otherwise>
+                    </c:choose>
+                </ul>
+            </nav>
+        </div>
+    </div>
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-3">
+                <div class="header__logo">
+                    <a href="${pageContext.request.contextPath}/page/main"><img src="${pageContext.request.contextPath}/img/logo.png" alt=""></a>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <nav class="header__menu">
+                    <ul id="header__menus" >
+                        <li><a href="${pageContext.request.contextPath}/page/main"  style="font-size: 20px; font-weight: 700;">홈</a></li>
+                        <li><a href="category.bit?view=1"  style="font-size: 20px; font-weight: 700;">도서 전체</a></li>
+                        <li class="active"><a href="${pageContext.request.contextPath}/page/contact" style="font-size: 20px; font-weight: 700;">고객센터</a></li>
+                    </ul>
+                </nav>
+            </div>
+            <c:choose>
+                <c:when test="${logincust != null }">
+                    <div class="col-lg-3">
+                        <div class="header__cart">
+                            <ul>
+                                <li><a href="main.bit?view=shopping-cart&memberSeq=${logincust.sequence }"><i class="fa fa-shopping-bag"></i> <span>${cartCount }</span></a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </div>
+</header>
+
+<script>
+    AOS.init({
+        easing: 'ease-out-back',
+        duration: 1000
+    });
+</script>
+
+<!-- Header Section End -->
+<!-- Hero Section Begin -->
+<section class="hero hero-normal">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-3">
+                <div class="hero__categories">
+                    <div class="hero__categories__all">
+                        <i class="fa fa-bars"></i> <span>카테고리</span>
+                    </div>
+                    <jsp:include page="common_categories.jsp" />
+                </div>
+            </div>
+            <div class="col-lg-9">
+                <div class="hero__search">
+                    <div class="hero__search__form">
+                        <form action="#"
+                              onsubmit="event.preventDefault(); search(document.getElementById('keyword').value);">
+                            <div class="hero__search__categories">통합 검색</div>
+                            <input type="text" id="keyword" placeholder="검색어를 입력해주세요">
+                            <button type="submit" class="site-btn">검색</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<!-- Hero Section End -->
+
+<!-- Breadcrumb Section Begin -->
+<section class="breadcrumb-section set-bg"
+         data-setbg="/img/books.jpg">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <div class="breadcrumb__text">
+                    <h2>에러페이지</h2>
+                    <div class="breadcrumb__option">
+                        <a href="index.jsp">Home</a> <span>에러발생</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<!-- Breadcrumb Section End -->
+
+<section class="d-flex flex-column justify-content-center align-items-center" style="height: 30vh;">
+    <h2 class="mb-3">${errorCode}</h2>
+    <h2>${errorMessage}</h2>
+
+</section>
+


### PR DESCRIPTION
## MR 이유
- [x] Feature 병합
- [ ] 버그 수정(아래에 상세 기입)
- [ ] 코드 개선
- [ ] 주기적인 master 병합
- [ ] 기타(아래에 상세 기입)

## 스크린샷 또는 세부 내용
- 세부사항을 항목으로 설명

### AOP를 이용해서 화면에 띄울 에러를 쉽게 관리하는 방법을 추가했습니다.
![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/c9c7560f-2a67-4aef-967f-4c565e9d7b1a)
### 위의 화면을 보면 정상적으로 잘 나오죠? shop-detail 페이지에서 sequence 5번을 받아옵니다.


![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/8c733d99-f86b-4852-b085-01371a8a1953)
### 999번을 넣었더니 상품이 없어서 에러페이지를 띄우는 것을 볼 수 있습니다. 이제 아래 설명을 보면서 따라해봅시다.

![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/68b1ad83-a67c-4b86-add3-2214ef842966)
### ErrorCode와 ErrorMessage를 관리할 ENUM 클래스를 만들었구요,

![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/961f08b6-1ea7-485d-b659-7cb3d2224e15)
### 해당 에러 코드를 받는 CustomException class와

![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/d04a1843-bb83-4e50-a6e9-f16ea0ae2cac)
### 해당 Exception을 던지면 알아서 받는 AOP역할을 하는 Handler 클래스를 추가했습니다.
### AOP란? (https://velog.io/@kai6666/Spring-Spring-AOP-%EA%B0%9C%EB%85%90)
### 재사용할 수 있는 로직을 어노테이션을 이용해서 중복코드 제거하고 사용하는 기법입니다. 테스트코드 작성할때 사용했죠?

### Contoller에 중복된 코드를 작성하지 않고, 해당 어노테이션이 CustomException.class를 Controller에서 받는걸 감지해서 (핸들러 클래스에 @ControllerAdvice 가 달려있음) 해당 로직을 발동시킵니다. 핸들러에는 에러페이지로 받아온 에러코드를 같이 넘기는 로직이 들어있습니다.

### 이제 이걸 어떻게 사용하는지 2-step으로 알아봅시다.
### 1. 에러코드에 코드와 메세지를 적어줍니다. ENUM타입이라서 ,로 구분하고 맨 마지막에만 ;를 달아줍니다.
![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/39bc228e-7485-4f7e-9c22-a19a0f76e1f3)

### 2. 에러 화면을 보여줄만한 상황의 조건이 걸리면 CustomException을 throw 해줍니다. controller에는 별도 로직 작성이 필요없습니다.
![image](https://github.com/CessnaJ/LOTBOOK2/assets/109272333/fb933bb5-eb5a-415c-801c-de806ee5a18c)



## MR 전 확인
- [x] 정상 작동
- [ ] Conflict 발생 - 팀원과의 상의 필요
